### PR TITLE
Add hero section after LogoTicker

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next"
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Footer } from "@/sections/Footer";
 import { Header } from "@/sections/Header";
 import { Hero } from "@/sections/Hero";
 import { LogoTicker } from "@/sections/LogoTicker";
+import { HeroAfterTicker } from "@/sections/HeroAfterTicker";
 import { Services } from "@/sections/Services";
 import { Testimonials } from "@/sections/Testimonials";
 import { Contact } from "@/sections/Contact";
@@ -16,6 +17,7 @@ export default function Home() {
         <Hero />
       </div>
       <LogoTicker />
+      <HeroAfterTicker />
       <div id="services">
         <Services />
       </div>

--- a/src/sections/HeroAfterTicker.tsx
+++ b/src/sections/HeroAfterTicker.tsx
@@ -1,0 +1,60 @@
+"use client";
+import ArrowRight from '../../public/assets/arrow-right.svg';
+import cogImage from '../../public/assets/bgg.png';
+import { motion } from 'framer-motion';
+
+export const HeroAfterTicker = () => {
+  return (
+    <section className='pt-8 pb-20 md:pt-5 md:pd-10 bg-[radial-gradient(ellipse_200%_100%_at_bottom_left,#c30011,#EAEEFE_100%)] overflow-x-clip'>
+      <div className="container">
+        <div className='md:flex items-center'>
+          <div className='md:w-[478px]'>
+            <h1 className="text-5xl md:text-7xl font-bold tracking-tighter text-[#000] bg-clip-text mt-6">La Clé de </h1>
+            <h1 className="text-5xl md:text-7xl font-bold tracking-tighter text-[#c30011] bg-clip-text">Votre Succès</h1>
+
+            <p className="text-xl text-[#000] tracking-tight mt-6">
+              Easy Ways Studio est une agence créative tout-en-un qui transforme vos idées en solutions digitales sur mesure :
+              sites web modernes, applications mobiles performantes, designs percutants, vidéos engageantes et stratégies réseaux sociaux efficaces.
+            </p>
+
+            <div className="flex gap-2 items-center mt-[30px] flex-wrap">
+              <a
+                href="#portfolio"
+              >
+                <button className="bg-black text-white px-4 py-2 rounded-lg font-medium tracking-tight">
+                  découvrir nos projets
+                </button>
+              </a>
+
+              <a
+                href="#contact"
+              >
+                <button className="btn btn-text gap-1">
+                  <span>démarrer votre projet</span>
+                  <ArrowRight className="h-5 w-5" />
+                </button>
+              </a>
+            </div>
+          </div>
+
+          <div className='mt-20 md:mt-0 md:h-[400px] md:flex-1 lg:h-[500px] relative'>
+            <motion.img
+              src={cogImage.src}
+              alt="Cog Image"
+              className='md:absolute md:h-full md:w-auto md:w-[460px] md:max-w-none md:-left-0 lg:-left-0 lg:w-[650px]'
+              animate={{
+                translateY: [-30, 30],
+              }}
+              transition={{
+                repeat: Infinity,
+                repeatType: "mirror",
+                duration: 3,
+                ease: 'easeInOut'
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/sections/Testimonials.tsx
+++ b/src/sections/Testimonials.tsx
@@ -87,8 +87,8 @@ const TestimonialsColumn = (props: { className?: string; testimonials: typeof te
       className="flex flex-col gap-6 pb-6">
       {[...new Array(2)].fill(0).map((_, index) => (
         <React.Fragment key={index}>
-          {props.testimonials.map(({ text, imageSrc, name, username }) => (
-            <div className="card">
+          {props.testimonials.map(({ text, imageSrc, name, username }, testimonialIndex) => (
+            <div className="card" key={`${index}-${testimonialIndex}`}>
               <div>
                 {text}
               </div>


### PR DESCRIPTION
## Summary
- add new `HeroAfterTicker` component
- show `HeroAfterTicker` after `LogoTicker` on the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688b3bb0b5cc8329a04e2cdec2045900