### PR TITLE
Add about page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,12 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "clsx": "^2.1.1",
         "framer-motion": "^11.15.0",
+        "i18next": "^25.3.2",
+        "lucide-react": "^0.535.0",
         "next": "14.2.4",
         "react": "^18",
         "react-dom": "^18",
+        "react-i18next": "^15.6.1",
         "react-icons": "^5.4.0"
       },
       "devDependencies": {
@@ -1915,7 +1918,6 @@
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
       "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5422,6 +5424,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -6192,6 +6234,15 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.535.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.535.0.tgz",
+      "integrity": "sha512-2E3+YWGLpjZ8ejIYrdqxVjWMSMiRQHmU6xZYE9xA2SC5j2m0NeB4/acjhRdhxbfniBKoNEukDDQnmShTxwOQ4g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/mdn-data": {
@@ -7029,6 +7080,32 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-icons": {
@@ -8207,7 +8284,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8350,6 +8427,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "clsx": "^2.1.1",
     "framer-motion": "^11.15.0",
+    "i18next": "^25.3.2",
+    "lucide-react": "^0.535.0",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-i18next": "^15.6.1",
     "react-icons": "^5.4.0"
   },
   "devDependencies": {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { ArrowLeft, Award, Users, Star, Clock, Target, Eye, Heart } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Header } from "@/sections/Header";
+import { Footer } from "@/sections/Footer";
+
+export default function AboutPage() {
+  const { t } = useTranslation();
+
+  const values = [
+    {
+      icon: Target,
+      title: t('aboutPage.value1Title'),
+      description: t('aboutPage.value1Description')
+    },
+    {
+      icon: Eye,
+      title: t('aboutPage.value2Title'),
+      description: t('aboutPage.value2Description')
+    },
+    {
+      icon: Heart,
+      title: t('aboutPage.value3Title'),
+      description: t('aboutPage.value3Description')
+    }
+  ];
+
+  const timeline = [
+    {
+      year: t('aboutPage.timeline1Year'),
+      title: t('aboutPage.timeline1Title'),
+      description: t('aboutPage.timeline1Description')
+    },
+    {
+      year: t('aboutPage.timeline2Year'),
+      title: t('aboutPage.timeline2Title'),
+      description: t('aboutPage.timeline2Description')
+    },
+    {
+      year: t('aboutPage.timeline3Year'),
+      title: t('aboutPage.timeline3Title'),
+      description: t('aboutPage.timeline3Description')
+    },
+    {
+      year: t('aboutPage.timeline4Year'),
+      title: t('aboutPage.timeline4Title'),
+      description: t('aboutPage.timeline4Description')
+    },
+    {
+      year: t('aboutPage.timeline5Year'),
+      title: t('aboutPage.timeline5Title'),
+      description: t('aboutPage.timeline5Description')
+    },
+    {
+      year: t('aboutPage.timeline6Year'),
+      title: t('aboutPage.timeline6Title'),
+      description: t('aboutPage.timeline6Description')
+    }
+  ];
+  return (
+    <div className="min-h-screen bg-studio-warm-bg">
+      <Header />
+      {/* Hero Section */}
+      <section className="pt-32 pb-20 bg-studio-warm-bg">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Link href="/">
+            <button className="flex items-center gap-2 text-studio-primary hover:text-studio-accent transition-colors duration-300 mb-8">
+              <ArrowLeft size={20} />
+              {t('aboutPage.backToHome')}
+            </button>
+          </Link>
+
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className="text-center max-w-4xl mx-auto"
+          >
+            <div className="mb-6">
+              <span className="inline-block px-6 py-2 bg-studio-primary text-white text-sm font-medium tracking-wide uppercase rounded-full">
+                {t('aboutPage.badge')}
+              </span>
+            </div>
+            <h1 className="font-heading text-5xl sm:text-6xl lg:text-7xl font-normal text-studio-primary mb-8 tracking-tight leading-tight">
+              {t('aboutPage.heading')} <span className="italic font-bold">{t('aboutPage.headingAccent')}</span> {t('aboutPage.headingAfter')}
+            </h1>
+            <p className="text-xl text-studio-text-light leading-relaxed max-w-3xl mx-auto">
+              {t('aboutPage.description')}
+            </p>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Mission & Vision */}
+      <section className="py-20 bg-background">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-16 items-center">
+            <motion.div
+              initial={{ opacity: 0, x: -30 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.8 }}
+              viewport={{ once: true }}
+            >
+              <h2 className="font-heading text-4xl sm:text-5xl font-normal text-studio-primary mb-8">
+                {t('aboutPage.missionHeading')} <span className="italic font-bold">{t('aboutPage.missionHeadingAccent')}</span>
+              </h2>
+              <p className="text-lg text-studio-text-light mb-6 leading-relaxed">
+                {t('aboutPage.missionDescription1')}
+              </p>
+              <p className="text-lg text-studio-text-light leading-relaxed">
+                {t('aboutPage.missionDescription2')}
+              </p>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, x: 30 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.8 }}
+              viewport={{ once: true }}
+              className="relative"
+            >
+              <img
+                src="https://images.unsplash.com/photo-1586023492125-27b2c045efd7?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=600"
+                alt="Design process"
+                className="w-full h-[500px] object-cover rounded-3xl"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-studio-primary/20 to-transparent rounded-3xl"></div>
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* Values */}
+      <section className="py-20 bg-studio-neutral">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="text-center mb-16"
+          >
+            <h2 className="font-heading text-4xl sm:text-5xl font-normal text-studio-primary mb-6">
+              {t('aboutPage.valuesHeading')} <span className="italic font-bold">{t('aboutPage.valuesHeadingAccent')}</span>
+            </h2>
+            <p className="text-lg text-studio-text-light max-w-3xl mx-auto">
+              {t('aboutPage.valuesDescription')}
+            </p>
+          </motion.div>
+
+          <div className="grid md:grid-cols-3 gap-8">
+            {values.map((value, index) => {
+              const IconComponent = value.icon;
+              return (
+                <motion.div
+                  key={index}
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6, delay: index * 0.1 }}
+                  viewport={{ once: true }}
+                  className="bg-card p-8 rounded-3xl shadow-soft hover-lift"
+                >
+                  <div className="w-16 h-16 bg-studio-primary rounded-2xl flex items-center justify-center mb-6">
+                    <IconComponent className="text-white" size={32} />
+                  </div>
+                  <h3 className="text-2xl font-semibold text-studio-primary mb-4">{value.title}</h3>
+                  <p className="text-studio-text-light leading-relaxed">{value.description}</p>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Timeline */}
+      <section className="py-20 bg-background">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="text-center mb-16"
+          >
+            <h2 className="font-heading text-4xl sm:text-5xl font-normal text-studio-primary mb-6">
+              {t('aboutPage.journeyHeading')} <span className="italic font-bold">{t('aboutPage.journeyHeadingAccent')}</span>
+            </h2>
+            <p className="text-lg text-studio-text-light max-w-3xl mx-auto">
+              {t('aboutPage.journeyDescription')}
+            </p>
+          </motion.div>
+
+          <div className="relative">
+            {/* Timeline line */}
+            <div className="absolute left-1/2 transform -translate-x-1/2 h-full w-1 bg-studio-neutral hidden lg:block"></div>
+
+            <div className="space-y-12">
+              {timeline.map((item, index) => (
+                <motion.div
+                  key={index}
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6, delay: index * 0.1 }}
+                  viewport={{ once: true }}
+                  className={`flex items-center ${index % 2 === 0 ? 'lg:flex-row' : 'lg:flex-row-reverse'}`}
+                >
+                  <div className="flex-1 lg:px-8">
+                    <div className={`bg-studio-neutral p-8 rounded-3xl shadow-soft ${index % 2 === 0 ? 'lg:text-right' : 'lg:text-left'}`}>
+                      <div className="text-3xl font-bold text-studio-primary mb-2">{item.year}</div>
+                      <h3 className="text-xl font-semibold text-studio-primary mb-3">{item.title}</h3>
+                      <p className="text-studio-text-light leading-relaxed">{item.description}</p>
+                    </div>
+                  </div>
+
+                  {/* Timeline dot */}
+                  <div className="hidden lg:block w-4 h-4 bg-studio-primary rounded-full relative z-10"></div>
+
+                  <div className="flex-1 lg:px-8"></div>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="py-20 bg-studio-primary text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="text-center mb-16"
+          >
+            <h2 className="font-heading text-4xl sm:text-5xl font-normal mb-6">
+              {t('aboutPage.numbersHeading')} <span className="italic font-bold">{t('aboutPage.numbersHeadingAccent')}</span>
+            </h2>
+            <p className="text-xl text-white/80 max-w-3xl mx-auto">
+              {t('aboutPage.numbersDescription')}
+            </p>
+          </motion.div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {[{ icon: Users, number: t('about.stat1Number'), label: t('about.stat1Label') }, { icon: Award, number: t('about.stat2Number'), label: t('about.stat2Label') }, { icon: Star, number: t('about.stat3Number'), label: t('about.stat3Label') }, { icon: Clock, number: t('about.stat4Number'), label: t('about.stat4Label') }].map((stat, index) => {
+              const IconComponent = stat.icon;
+              return (
+                <motion.div
+                  key={index}
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6, delay: index * 0.1 }}
+                  viewport={{ once: true }}
+                  className="text-center"
+                >
+                  <div className="w-16 h-16 bg-white/10 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                    <IconComponent className="text-white" size={32} />
+                  </div>
+                  <div className="text-4xl font-bold mb-2">{stat.number}</div>
+                  <div className="text-xl font-semibold">{stat.label}</div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/sections/AboutSection.tsx
+++ b/src/sections/AboutSection.tsx
@@ -1,0 +1,228 @@
+"use client";
+import React from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Award, Users, Star, Clock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export default function AboutSection() {
+  const { t } = useTranslation();
+
+  const stats = [
+    {
+      icon: Users,
+      number: t('about.stat1Number'),
+      label: t('about.stat1Label'),
+      description: t('about.stat1Description'),
+    },
+    {
+      icon: Award,
+      number: t('about.stat2Number'),
+      label: t('about.stat2Label'),
+      description: t('about.stat2Description'),
+    },
+    {
+      icon: Star,
+      number: t('about.stat3Number'),
+      label: t('about.stat3Label'),
+      description: t('about.stat3Description'),
+    },
+    {
+      icon: Clock,
+      number: t('about.stat4Number'),
+      label: t('about.stat4Label'),
+      description: t('about.stat4Description'),
+    },
+  ];
+  return (
+    <section id="about" className="py-24 bg-studio-neutral scroll-mt-20">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Main Content */}
+        <div className="grid lg:grid-cols-2 gap-16 items-center mb-20 animate-fade-in">
+          {/* Text Content */}
+          <motion.div
+            initial={{ opacity: 0, x: -30 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="animate-slide-up"
+          >
+            <div className="mb-6">
+              <span className="inline-block px-6 py-2 bg-studio-primary text-white text-sm font-medium tracking-wide uppercase rounded-full">
+                {t('about.badge')}
+              </span>
+            </div>
+
+            <h2 className="font-heading text-4xl sm:text-5xl lg:text-6xl font-normal text-studio-primary mb-8 tracking-tight leading-tight animate-zoom-in">
+              {t('about.headingBefore')} <span className="italic font-bold">{t('about.headingAccent')}</span> {t('about.headingAfter')}
+            </h2>
+
+            <p className="text-xl text-studio-text-light mb-8 leading-relaxed">
+              {t('about.description1')}
+            </p>
+
+            <p className="text-lg text-studio-text-light mb-8 leading-relaxed">
+              {t('about.description2')}
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4">
+              <Link href="/about">
+                <button className="bg-studio-primary hover:bg-studio-accent text-white px-8 py-4 text-lg font-medium hover-lift rounded-full border-2 border-studio-primary hover:border-studio-accent transition-all duration-300 animate-float">
+                  {t('about.ctaLearnMore')}
+                </button>
+              </Link>
+              <Link href="/process">
+                <button className="border-2 border-studio-primary hover:bg-studio-primary hover:text-white text-studio-primary px-8 py-4 text-lg font-medium hover-lift rounded-full transition-all duration-300 animate-float">
+                  {t('about.ctaProcess')}
+                </button>
+              </Link>
+            </div>
+          </motion.div>
+
+          {/* Image */}
+          <motion.div
+            initial={{ opacity: 0, x: 30 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="relative animate-zoom-in"
+          >
+            <div className="relative overflow-hidden rounded-3xl">
+              <img
+                src="https://images.unsplash.com/photo-1618221195710-dd6b41faaea6?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=1000"
+                alt="Modern interior design showcase"
+                className="w-full h-[600px] object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-studio-primary/20 to-transparent"></div>
+            </div>
+
+            {/* Floating Stats Card */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.4 }}
+              viewport={{ once: true }}
+              className="absolute -bottom-8 -left-8 bg-card p-8 rounded-2xl shadow-3xl"
+            >
+              <div className="text-center">
+                <div className="text-3xl font-bold text-studio-primary mb-2">
+                  {t('about.stat2Number')}
+                </div>
+                <div className="text-studio-text-light font-medium">
+                  {t('about.floatingCardText')}
+                </div>
+              </div>
+            </motion.div>
+          </motion.div>
+        </div>
+
+        {/* Stats Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          viewport={{ once: true }}
+          className="bg-card rounded-3xl p-12 shadow-soft animate-slide-up"
+        >
+          <div className="text-center mb-12">
+            <h3 className="font-heading text-3xl sm:text-4xl font-normal text-studio-primary mb-4">
+              {t('about.statsHeading')} <span className="italic font-bold">{t('about.statsHeadingAccent')}</span>
+            </h3>
+            <p className="text-lg text-studio-text-light max-w-2xl mx-auto">
+              {t('about.statsDescription')}
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {stats.map((stat, index) => {
+              const IconComponent = stat.icon;
+              return (
+                <motion.div
+                  key={index}
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6, delay: index * 0.1 }}
+                  viewport={{ once: true }}
+                  className="text-center animate-fade-in"
+                >
+                  <div className="w-16 h-16 bg-studio-primary rounded-2xl flex items-center justify-center mx-auto mb-4">
+                    <IconComponent className="text-white" size={32} />
+                  </div>
+                  <div className="text-4xl font-bold text-studio-primary mb-2">
+                    {stat.number}
+                  </div>
+                  <div className="text-xl font-semibold text-studio-primary mb-2">
+                    {stat.label}
+                  </div>
+                  <p className="text-studio-text-light text-sm leading-relaxed">
+                    {stat.description}
+                  </p>
+                </motion.div>
+              );
+            })}
+          </div>
+        </motion.div>
+
+        {/* Team Preview */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          viewport={{ once: true }}
+          className="mt-20 text-center"
+        >
+          <h3 className="font-heading text-3xl sm:text-4xl font-normal text-studio-primary mb-6">
+            {t('about.teamHeading')} <span className="italic font-bold">{t('about.teamHeadingAccent')}</span>
+          </h3>
+          <p className="text-lg text-studio-text-light mb-12 max-w-3xl mx-auto">
+            {t('about.teamDescription')}
+          </p>
+
+          <div className="grid md:grid-cols-3 gap-8">
+            {[
+              {
+                name: "Sarah Johnson",
+                role: "Lead Interior Designer",
+                image: "/logos/sarah-johnson.jpg",
+              },
+              {
+                name: "Michael Chen",
+                role: "Senior Architect",
+                image:
+                  "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&h=400",
+              },
+              {
+                name: "Emma Rodriguez",
+                role: "Project Manager",
+                image:
+                  "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&h=400",
+              },
+            ].map((member, index) => (
+              <motion.div
+                key={index}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: index * 0.1 }}
+                viewport={{ once: true }}
+                className="group"
+              >
+                <div className="relative overflow-hidden rounded-2xl mb-4">
+                  <img
+                    src={member.image}
+                    alt={member.name}
+                    className="w-full h-80 object-cover group-hover:scale-105 transition-transform duration-500"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-studio-primary/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                </div>
+                <h4 className="text-xl font-semibold text-studio-primary mb-1">
+                  {member.name}
+                </h4>
+                <p className="text-studio-text-light">{member.role}</p>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/AboutStorySection.tsx
+++ b/src/sections/AboutStorySection.tsx
@@ -1,0 +1,196 @@
+"use client";
+import React from "react";
+import { motion } from "framer-motion";
+import { Award, Users, Calendar, Trophy } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export default function AboutStorySection() {
+  const { t } = useTranslation();
+
+  const stats = [
+    {
+      icon: Calendar,
+      value: t('aboutStory.stat1Value'),
+      label: t('aboutStory.stat1Label'),
+      description: t('aboutStory.stat1Description')
+    },
+    {
+      icon: Users,
+      value: t('aboutStory.stat2Value'),
+      label: t('aboutStory.stat2Label'),
+      description: t('aboutStory.stat2Description')
+    },
+    {
+      icon: Trophy,
+      value: t('aboutStory.stat3Value'),
+      label: t('aboutStory.stat3Label'),
+      description: t('aboutStory.stat3Description')
+    },
+    {
+      icon: Award,
+      value: t('aboutStory.stat4Value'),
+      label: t('aboutStory.stat4Label'),
+      description: t('aboutStory.stat4Description')
+    }
+  ];
+
+  const services = [
+    t('aboutStory.service1'),
+    t('aboutStory.service2'),
+    t('aboutStory.service3'),
+    t('aboutStory.service4'),
+    t('aboutStory.service5'),
+    t('aboutStory.service6'),
+    t('aboutStory.service7'),
+    t('aboutStory.service8')
+  ];
+
+  return (
+    <section className="py-20 bg-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          viewport={{ once: true }}
+          className="text-center mb-16"
+        >
+          <p className="studio-accent font-semibold text-lg mb-4">{t('aboutStory.badge')}</p>
+          <h2 className="text-4xl lg:text-5xl font-bold studio-primary mb-6">
+            {t('aboutStory.heading')}
+          </h2>
+          <p className="text-xl studio-text-light max-w-4xl mx-auto leading-relaxed">
+            {t('aboutStory.description')}
+          </p>
+        </motion.div>
+
+        {/* Gallery Grid */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          viewport={{ once: true }}
+          className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-4 mb-20"
+        >
+          <img
+            src="https://images.unsplash.com/photo-1586023492125-27b2c045efd7?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&h=300"
+            alt="Interior design showcase 1"
+            className="rounded-xl shadow-lg w-full h-48 object-cover hover-lift"
+          />
+          <img
+            src="https://images.unsplash.com/photo-1556020685-ae41abfc9365?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&h=300"
+            alt="Interior design showcase 2"
+            className="rounded-xl shadow-lg w-full h-48 object-cover hover-lift"
+          />
+          <img
+            src="https://images.unsplash.com/photo-1584622650111-993a426fbf0a?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&h=300"
+            alt="Interior design showcase 3"
+            className="rounded-xl shadow-lg w-full h-48 object-cover hover-lift"
+          />
+          <img
+            src="https://images.unsplash.com/photo-1565182999561-18d7dc61c393?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&h=300"
+            alt="Interior design showcase 4"
+            className="rounded-xl shadow-lg w-full h-48 object-cover hover-lift"
+          />
+          <img
+            src="https://images.unsplash.com/photo-1567767292278-a4f21aa2d36e?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&h=300"
+            alt="Interior design showcase 5"
+            className="rounded-xl shadow-lg w-full h-48 object-cover hover-lift"
+          />
+        </motion.div>
+
+        {/* Story and Approach */}
+        <div className="grid lg:grid-cols-2 gap-12 mb-20">
+          <motion.div
+            initial={{ opacity: 0, x: -50 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="space-y-6"
+          >
+            <p className="studio-accent font-semibold text-lg">{t('aboutStory.visionBadge')}</p>
+            <h3 className="text-3xl font-bold studio-primary">{t('aboutStory.storyHeading')}</h3>
+            <p className="text-lg studio-text-light leading-relaxed">
+              {t('aboutStory.storyDescription1')}
+            </p>
+            <p className="text-lg studio-text-light leading-relaxed">
+              {t('aboutStory.storyDescription2')}
+            </p>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, x: 50 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.8 }}
+            viewport={{ once: true }}
+            className="space-y-6"
+          >
+            <p className="studio-accent font-semibold text-lg">{t('aboutStory.agencyBadge')}</p>
+            <h3 className="text-3xl font-bold studio-primary">{t('aboutStory.approachHeading')}</h3>
+            <p className="text-lg studio-text-light leading-relaxed">
+              {t('aboutStory.approachDescription1')}
+            </p>
+            <p className="text-lg studio-text-light leading-relaxed">
+              {t('aboutStory.approachDescription2')}
+            </p>
+          </motion.div>
+        </div>
+
+        {/* Stats */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          viewport={{ once: true }}
+          className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 mb-20"
+        >
+          {stats.map((stat, index) => {
+            const IconComponent = stat.icon;
+            return (
+              <div
+                key={index}
+                className="text-center bg-studio-neutral p-8 rounded-xl hover:shadow-lg transition-all duration-300"
+              >
+                <div className="w-16 h-16 bg-studio-accent rounded-lg flex items-center justify-center mx-auto mb-4">
+                  <IconComponent className="text-white" size={32} />
+                </div>
+                <h4 className="text-3xl font-bold studio-primary mb-2">{stat.value}</h4>
+                <p className="font-semibold studio-primary mb-2">{stat.label}</p>
+                <p className="text-sm studio-text-light">{stat.description}</p>
+              </div>
+            );
+          })}
+        </motion.div>
+
+        {/* Services */}
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          viewport={{ once: true }}
+          className="text-center"
+        >
+          <h3 className="text-3xl font-bold studio-primary mb-8">{t('aboutStory.qualityHeading')}</h3>
+          <p className="text-lg studio-text-light mb-8 max-w-3xl mx-auto">
+            {t('aboutStory.qualityDescription')}
+          </p>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {services.map((service, index) => (
+              <motion.div
+                key={index}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: index * 0.1 }}
+                viewport={{ once: true }}
+                className="bg-card p-6 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover-lift"
+              >
+                <p className="font-semibold studio-primary">{service}</p>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Testimonials.tsx
+++ b/src/sections/Testimonials.tsx
@@ -87,8 +87,8 @@ const TestimonialsColumn = (props: { className?: string; testimonials: typeof te
       className="flex flex-col gap-6 pb-6">
       {[...new Array(2)].fill(0).map((_, index) => (
         <React.Fragment key={index}>
-          {props.testimonials.map(({ text, imageSrc, name, username }) => (
-            <div className="card">
+          {props.testimonials.map(({ text, imageSrc, name, username }, testimonialIndex) => (
+            <div className="card" key={`${index}-${testimonialIndex}`}>
               <div>
                 {text}
               </div>


### PR DESCRIPTION
## Summary
- replace `HeroAfterTicker` with new about sections and page
- remove hero ticker import from homepage
- add i18n and icon dependencies for new page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688b3bb0b5cc8329a04e2cdec2045900